### PR TITLE
Command Injection in ChippyRuxpin.py

### DIFF
--- a/chippyRuxpin.py
+++ b/chippyRuxpin.py
@@ -95,7 +95,7 @@ def talk(myText):
     
     os.system( "espeak \",...\" 2>/dev/null" ) # Sometimes the beginning of audio can get cut off. Insert silence.
     time.sleep( 0.5 )
-    os.system( "espeak -w speech.wav \"" + myText + "\" -s 130" )
+    subprocess.call(["espeak", "-w", "speech.wav", myText, "-s", "130"])
     audio.play("speech.wav")
     return myText
 


### PR DESCRIPTION
Anything passed in to the "speech" param from the web interface (or from twitter) becomes part of the command line espeak call. 

Sending something like: 
```bash
hi"; echo hi > xxx.txt
```
in the input box would create a file called xxx.txt in the same folder chippyRuxpin is running in. An attacker could do much worse considering chippyRuxpin requires **root** to run. 

```python
speech = request.forms.get('speech')  # chippyRuxpin_webFramework.py: 28 
self.talkFunc( speech ); # chippyRuxpin_webFramework.py: 29
```
```python
def talk(myText): #chippyRuxpin.py: 86
    ...
    os.system( "espeak -w speech.wav \"" + myText + "\" -s 130" ) # chippyRuxpin.py: 98
```

Prevent remote code execution by passing arguments to subprocess.call instead of os.system
```python
subprocess.call(["espeak", "-w", "speech.wav", myText, "-s", "130"])
```